### PR TITLE
Fix failing titanic_benchmark_test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Documentation
 docs/build*
 
+# Logs
+*.log
+
 # Compiled python modules.
 *.pyc
 
@@ -23,6 +26,9 @@ dist/
 # Sublime project files
 *.sublime-project
 *.sublime-workspace
+
+# VSCode
+.vscode/
 
 # Tests
 .pytest_cache/

--- a/examples/auto_estimator_trainer.py
+++ b/examples/auto_estimator_trainer.py
@@ -27,7 +27,7 @@ import tensorflow as tf
 import tensorflow_model_analysis as tfma
 import tensorflow_transform as tft
 
-from google3.third_party.tensorflow_metadata.proto.v0 import schema_pb2
+from tensorflow_metadata.proto.v0 import schema_pb2
 from tfx.components.trainer import executor as trainer_executor
 
 FeatureColumn = Any

--- a/examples/titanic_benchmark_test.py
+++ b/examples/titanic_benchmark_test.py
@@ -21,6 +21,7 @@
 
 import json
 import os
+import sys
 import tempfile
 
 from absl import flags
@@ -34,21 +35,29 @@ from ml_metadata.metadata_store import metadata_store
 from ml_metadata.proto import metadata_store_pb2
 
 
-
 class TitanicBenchmarkTest(e2etest.TestCase):
 
   def setUp(self):
     super(TitanicBenchmarkTest, self).setUp()
+    flags.FLAGS(sys.argv)
+
     tempdir = tempfile.mkdtemp(dir=absltest.get_default_test_tmpdir())
-    pipeline_name = "nitroml_titanic_benchmark"
+    self._pipeline_name = "nitroml_titanic_benchmark"
     self._pipeline_root = os.path.join(tempdir, "nitroml", "titanic",
-                                       pipeline_name)
+                                       self._pipeline_name)
     self._metadata_path = os.path.join(tempdir, "nitroml", "titanic",
-                                       pipeline_name, "metadata.db")
+                                       self._pipeline_name, "metadata.db")
 
   def test(self):
+    metadata_config = metadata_store_pb2.ConnectionConfig(
+        sqlite=metadata_store_pb2.SqliteMetadataSourceConfig(
+            filename_uri=self._metadata_path))
 
-    nitroml.run([titanic_benchmark.TitanicBenchmark()])
+    nitroml.run([titanic_benchmark.TitanicBenchmark()],
+                pipeline_name=self._pipeline_name,
+                pipeline_root=self._pipeline_root,
+                metadata_connection_config=metadata_config,
+                beam_pipeline_args=['defaultWorkerLogLevel=ERROR'])
 
     self.assertComponentExecutionCount(7, self._metadata_path)
     self.assertComponentSucceeded("ImportExampleGen.TitanicBenchmark.benchmark",
@@ -68,9 +77,6 @@ class TitanicBenchmarkTest(e2etest.TestCase):
         self._metadata_path)
 
     # Load benchmark results.
-    metadata_config = metadata_store_pb2.ConnectionConfig(
-        sqlite=metadata_store_pb2.SqliteMetadataSourceConfig(
-            filename_uri=self._metadata_path))
     store = metadata_store.MetadataStore(metadata_config)
     df = results.overview(store)
 


### PR DESCRIPTION
Update `nitroml` package to automatically create pipeline directories for the user.